### PR TITLE
Organize lib file, some minor changes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "webdriver-downloader"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webdriver-downloader"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["ik1ne <ik1ne@naver.com>"]
 description = "Cli Interface&Library for webdriver download."

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 
-use crate::driver_management::chromedriver_info::ChromedriverInfo;
-use crate::driver_management::download_verify_install;
+use webdriver_downloader::*;
 
 use super::build_arg::*;
 use super::check_arg::*;

--- a/src/driver_management.rs
+++ b/src/driver_management.rs
@@ -3,15 +3,16 @@ use std::fs::rename;
 use anyhow::{bail, Context};
 use tempfile::TempDir;
 
+pub use chromedriver_info::ChromedriverInfo;
 pub use installation_info::WebdriverInstallationInfo;
 pub use url_info::WebdriverUrlInfo;
 pub use verification_info::WebdriverVerificationInfo;
 
+mod binary_exact_version_hint_url_info;
 pub mod chromedriver_info;
 pub mod installation_info;
 pub mod url_info;
 pub mod verification_info;
-mod binary_exact_version_hint_url_info;
 
 pub trait WebdriverInfo:
     WebdriverUrlInfo + WebdriverInstallationInfo + WebdriverVerificationInfo + Sync

--- a/src/driver_management.rs
+++ b/src/driver_management.rs
@@ -11,6 +11,7 @@ pub mod chromedriver_info;
 pub mod installation_info;
 pub mod url_info;
 pub mod verification_info;
+mod binary_exact_version_hint_url_info;
 
 pub trait WebdriverInfo:
     WebdriverUrlInfo + WebdriverInstallationInfo + WebdriverVerificationInfo + Sync

--- a/src/driver_management.rs
+++ b/src/driver_management.rs
@@ -8,12 +8,13 @@ pub use installation_info::WebdriverInstallationInfo;
 pub use url_info::WebdriverUrlInfo;
 pub use verification_info::WebdriverVerificationInfo;
 
-mod binary_exact_version_hint_url_info;
-pub mod chromedriver_info;
-pub mod installation_info;
-pub mod url_info;
-pub mod verification_info;
+mod binary_major_version_hint_url_info;
+mod chromedriver_info;
+mod installation_info;
+mod url_info;
+mod verification_info;
 
+/// Information required to download, verify, install driver.
 pub trait WebdriverInfo:
     WebdriverUrlInfo + WebdriverInstallationInfo + WebdriverVerificationInfo + Sync
 {
@@ -37,10 +38,8 @@ pub async fn download_verify_install(
         let temp_driver_path = driver_info.download_in_tempdir(url, &tempdir).await?;
 
         if driver_info.verify_driver(&temp_driver_path).await.is_ok() {
-            rename(temp_driver_path, driver_info.driver_install_path())
-                .with_context(|| "Failed to install driver to driver_path.")?;
-
-            return Ok(());
+            return rename(temp_driver_path, driver_info.driver_install_path())
+                .with_context(|| "Failed to install driver to driver_path.");
         }
     }
 

--- a/src/driver_management/binary_exact_version_hint_url_info.rs
+++ b/src/driver_management/binary_exact_version_hint_url_info.rs
@@ -1,0 +1,64 @@
+use std::cmp::Ordering;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use semver::Version;
+
+use crate::WebdriverUrlInfo;
+
+pub struct VersionUrl {
+    pub driver_version: Version,
+    pub url: String,
+}
+
+#[async_trait]
+pub trait BinaryExactVersionHintUrlInfo {
+    /// Version hint based on browser's version.
+    fn binary_version(&self) -> Option<Version>;
+
+    /// Compares versions based on version_hint.
+    /// Prioritizes same major version to version_hint, and then latest version.
+    fn compare_version(version_hint: &Version, left: &Version, right: &Version) -> Ordering {
+        let left_match = version_hint.major == left.major;
+        let right_match = version_hint.major == right.major;
+        match (left_match, right_match) {
+            (true, false) => Ordering::Greater,
+            (false, true) => Ordering::Less,
+            _ => left.cmp(right),
+        }
+    }
+
+    /// [`VersionUrl`]s, probably parsed from driver's download page.
+    async fn driver_version_urls(&self) -> Result<Vec<VersionUrl>>;
+
+    async fn driver_urls(&self, limit: usize) -> Result<Vec<String>> {
+        let mut url_infos = self.driver_version_urls().await?;
+
+        if let Some(version_hint) = self.binary_version() {
+            url_infos.sort_by(|left, right| {
+                Self::compare_version(&version_hint, &right.driver_version, &left.driver_version)
+            });
+        } else {
+            url_infos.sort_by(|left, right| right.driver_version.cmp(&left.driver_version))
+        }
+
+        if url_infos.len() > limit {
+            url_infos.drain(limit..);
+        }
+
+        Ok(url_infos
+            .into_iter()
+            .map(|version_url| version_url.url)
+            .collect())
+    }
+}
+
+#[async_trait]
+impl<T> WebdriverUrlInfo for T
+where
+    T: BinaryExactVersionHintUrlInfo + Sync,
+{
+    async fn driver_urls(&self, limit: usize) -> Result<Vec<String>> {
+        self.driver_urls(limit).await
+    }
+}

--- a/src/driver_management/binary_major_version_hint_url_info.rs
+++ b/src/driver_management/binary_major_version_hint_url_info.rs
@@ -12,11 +12,11 @@ pub struct VersionUrl {
 }
 
 #[async_trait]
-pub trait BinaryExactVersionHintUrlInfo: WebdriverUrlInfo {
-    /// Version hint based on browser's version.
+pub trait BinaryMajorVersionHintUrlInfo: WebdriverUrlInfo {
+    /// Version hint. used by [compare_version](BinaryMajorVersionHintUrlInfo::driver_urls).
     fn binary_version(&self) -> Option<Version>;
 
-    /// Compares versions based on version_hint.
+    /// Compares versions based on `version_hint`.
     /// Prioritizes same major version to version_hint, and then latest version.
     fn compare_version(version_hint: &Version, left: &Version, right: &Version) -> Ordering {
         let left_match = version_hint.major == left.major;
@@ -35,7 +35,7 @@ pub trait BinaryExactVersionHintUrlInfo: WebdriverUrlInfo {
 #[async_trait]
 impl<T> WebdriverUrlInfo for T
 where
-    T: BinaryExactVersionHintUrlInfo + Sync,
+    T: BinaryMajorVersionHintUrlInfo + Sync,
 {
     async fn driver_urls(&self, limit: usize) -> Result<Vec<String>> {
         let mut url_infos = self.driver_version_urls().await?;

--- a/src/driver_management/chromedriver_info.rs
+++ b/src/driver_management/chromedriver_info.rs
@@ -8,8 +8,10 @@ use regex::Regex;
 use semver::Version;
 use serde_json::json;
 
-use crate::driver_management::url_info::VersionUrl;
-use crate::{WebdriverInstallationInfo, WebdriverUrlInfo, WebdriverVerificationInfo};
+use crate::driver_management::binary_exact_version_hint_url_info::{
+    BinaryExactVersionHintUrlInfo, VersionUrl,
+};
+use crate::{WebdriverInstallationInfo, WebdriverVerificationInfo};
 
 pub struct ChromedriverInfo {
     driver_install_path: PathBuf,
@@ -26,8 +28,8 @@ impl ChromedriverInfo {
 }
 
 #[async_trait]
-impl WebdriverUrlInfo for ChromedriverInfo {
-    fn driver_version_hint(&self) -> Option<Version> {
+impl BinaryExactVersionHintUrlInfo for ChromedriverInfo {
+    fn binary_version(&self) -> Option<Version> {
         let mut child = std::process::Command::new("powershell");
 
         child

--- a/src/driver_management/installation_info.rs
+++ b/src/driver_management/installation_info.rs
@@ -15,7 +15,7 @@ pub trait WebdriverInstallationInfo {
     fn driver_install_path(&self) -> &Path;
 
     /// Driver executable name in archive file.
-    fn driver_name_in_zip(&self) -> &'static str;
+    fn driver_name_in_archive(&self) -> &'static str;
 
     /// Downloads url and extracts the driver inside tempdir.
     async fn download_in_tempdir<U: IntoUrl + Send>(
@@ -28,9 +28,9 @@ pub trait WebdriverInstallationInfo {
         let content = Cursor::new(response.bytes().await?);
 
         let mut archive = ZipArchive::new(content)?;
-        let mut driver_content = archive.by_name(self.driver_name_in_zip())?;
+        let mut driver_content = archive.by_name(self.driver_name_in_archive())?;
 
-        let driver_path = dir.path().join(self.driver_name_in_zip());
+        let driver_path = dir.path().join(self.driver_name_in_archive());
         let mut driver_file = File::create(&driver_path)?;
         io::copy(&mut driver_content, &mut driver_file)?;
 

--- a/src/driver_management/url_info.rs
+++ b/src/driver_management/url_info.rs
@@ -1,56 +1,9 @@
-use std::cmp::Ordering;
-
 use anyhow::Result;
 use async_trait::async_trait;
-use semver::Version;
-
-pub struct VersionUrl {
-    pub driver_version: Version,
-    pub url: String,
-}
 
 /// Provides information for determining which url to download.
 #[async_trait]
 pub trait WebdriverUrlInfo {
-    /// Version hint based on browser's version.
-    fn driver_version_hint(&self) -> Option<Version>;
-
-    /// Compares versions based on version_hint.
-    /// Prioritizes same major version to version_hint, and then latest version.
-    fn compare_version(version_hint: &Version, left: &Version, right: &Version) -> Ordering {
-        let left_match = version_hint.major == left.major;
-        let right_match = version_hint.major == right.major;
-        match (left_match, right_match) {
-            (true, false) => Ordering::Greater,
-            (false, true) => Ordering::Less,
-            _ => left.cmp(right),
-        }
-    }
-
-    /// [`VersionUrl`]s, probably parsed from driver's download page.
-    async fn driver_version_urls(&self) -> Result<Vec<VersionUrl>>;
-
-    /// Lists viable driver urls based on [driver_url_infos](WebdriverUrlInfo::driver_version_urls) and limit.
-    ///
-    /// If [driver_version_hint](WebdriverUrlInfo::driver_version_hint) returns Some, driver version with same major versions will be tried first.
-    async fn driver_urls(&self, limit: usize) -> Result<Vec<String>> {
-        let mut url_infos = self.driver_version_urls().await?;
-
-        if let Some(version_hint) = self.driver_version_hint() {
-            url_infos.sort_by(|left, right| {
-                Self::compare_version(&version_hint, &right.driver_version, &left.driver_version)
-            });
-        } else {
-            url_infos.sort_by(|left, right| right.driver_version.cmp(&left.driver_version))
-        }
-
-        if url_infos.len() > limit {
-            url_infos.drain(limit..);
-        }
-
-        Ok(url_infos
-            .into_iter()
-            .map(|version_url| version_url.url)
-            .collect())
-    }
+    /// Lists viable driver urls, up to `limit`.
+    async fn driver_urls(&self, limit: usize) -> Result<Vec<String>>;
 }

--- a/src/driver_management/verification_info.rs
+++ b/src/driver_management/verification_info.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use fantoccini::wd::Capabilities;
 use fantoccini::Locator;
 
-/// Provides information for verifying an installed driver.
+/// Provides information for verifying a webdriver.
 #[async_trait]
 pub trait WebdriverVerificationInfo {
     /// Capabilities to use for verification.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,3 @@
-pub use driver_management::chromedriver_info::ChromedriverInfo;
-pub use driver_management::download_verify_install;
-pub use driver_management::{
-    WebdriverInstallationInfo, WebdriverUrlInfo, WebdriverVerificationInfo,
-};
+pub use driver_management::*;
 
-pub mod cli;
-
-pub mod driver_management;
+mod driver_management;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use webdriver_downloader::cli;
+mod cli;
 
 #[tokio::main]
 async fn main() -> Result<()> {


### PR DESCRIPTION
- Move run::run to cli.rs instead of lib.rs
- Add BinaryMajorVersionHintUrlInfo trait. It can be used to support webdrivers which releases the same major version as browser version.
- #2 : Now uses OsString.push method to properly construct command. (instead of String format.) 