### PR TITLE
Refactor: change binary_version_hint_url_info.rs

### DIFF
--- a/webdriver-downloader/src/driver_management/common/mod.rs
+++ b/webdriver-downloader/src/driver_management/common/mod.rs
@@ -1,4 +1,4 @@
-pub mod binary_version_hint_url_info;
+pub mod version_req_url_info;
 
 pub mod installation_info;
 pub mod url_info;

--- a/webdriver-downloader/src/driver_management/common/url_info.rs
+++ b/webdriver-downloader/src/driver_management/common/url_info.rs
@@ -1,14 +1,14 @@
 use async_trait::async_trait;
 use semver::Version;
 
-use crate::common::binary_version_hint_url_info::BinaryVersionError;
+use crate::common::version_req_url_info::VersionReqError;
 
 #[derive(thiserror::Error, Debug)]
 pub enum UrlError {
     #[error("Failed to download Urls: {0}")]
     Download(#[from] reqwest::Error),
     #[error(transparent)]
-    BinaryVersion(#[from] BinaryVersionError),
+    BinaryVersion(#[from] VersionReqError),
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }

--- a/webdriver-downloader/src/driver_management/driver_impls/chromedriver_info/mod.rs
+++ b/webdriver-downloader/src/driver_management/driver_impls/chromedriver_info/mod.rs
@@ -4,10 +4,10 @@ use anyhow::Context;
 use async_trait::async_trait;
 use fantoccini::wd::Capabilities;
 use regex::Regex;
-use semver::Version;
+use semver::VersionReq;
 use serde_json::{json, Map};
 
-use crate::common::binary_version_hint_url_info::{BinaryVersionError, BinaryVersionHintUrlInfo};
+use crate::common::version_req_url_info::{VersionReqError, VersionReqUrlInfo};
 use crate::common::installation_info::WebdriverInstallationInfo;
 use crate::common::url_info::{UrlError, VersionUrl};
 use crate::common::verification_info::WebdriverVerificationInfo;
@@ -30,9 +30,10 @@ impl ChromedriverInfo {
 }
 
 #[async_trait]
-impl BinaryVersionHintUrlInfo for ChromedriverInfo {
-    fn binary_version(&self) -> Result<Version, BinaryVersionError> {
-        os_specific::binary_version(&self.browser_path)
+impl VersionReqUrlInfo for ChromedriverInfo {
+    fn version_req(&self) -> Result<VersionReq, VersionReqError> {
+        let version_string = format!("^{}", os_specific::binary_version(&self.browser_path)?);
+        VersionReq::parse(&version_string).map_err(|e| e.into())
     }
 
     async fn driver_version_urls(&self) -> Result<Vec<VersionUrl>, UrlError> {
@@ -91,7 +92,7 @@ impl WebdriverVerificationInfo for ChromedriverInfo {
 
 #[cfg(test)]
 mod tests {
-    use crate::common::binary_version_hint_url_info::BinaryVersionHintUrlInfo;
+    use crate::common::version_req_url_info::VersionReqUrlInfo;
     use crate::driver_impls::ChromedriverInfo;
 
     #[test]
@@ -108,6 +109,6 @@ mod tests {
             browser_path: browser_path.into(),
         };
 
-        assert!(chromedriver_info.binary_version().is_ok());
+        assert!(chromedriver_info.version_req().is_ok());
     }
 }

--- a/webdriver-downloader/src/driver_management/driver_impls/chromedriver_info/os_specific/unix_family.rs
+++ b/webdriver-downloader/src/driver_management/driver_impls/chromedriver_info/os_specific/unix_family.rs
@@ -3,9 +3,9 @@ use std::path::Path;
 use regex::Regex;
 use semver::Version;
 
-use crate::common::binary_version_hint_url_info::BinaryVersionError;
+use crate::common::version_req_url_info::VersionReqError;
 
-pub fn binary_version(browser_path: &Path) -> Result<Version, BinaryVersionError> {
+pub fn binary_version(browser_path: &Path) -> Result<Version, VersionReqError> {
     let re = Regex::new(r"([0-9\.]+)").expect("Failed to parse regex.");
     let output = std::process::Command::new(browser_path)
         .arg(Path::new("--version"))
@@ -13,7 +13,7 @@ pub fn binary_version(browser_path: &Path) -> Result<Version, BinaryVersionError
 
     let chrome_version_string = String::from_utf8_lossy(&output.stdout);
     let version_string = capture_regex_from_string(&re, &chrome_version_string).ok_or(
-        BinaryVersionError::RegexError(chrome_version_string.to_string()),
+        VersionReqError::RegexError(chrome_version_string.to_string()),
     )?;
 
     lenient_semver::parse(&version_string).map_err(|e| e.owned().into())

--- a/webdriver-downloader/src/driver_management/driver_impls/chromedriver_info/os_specific/windows.rs
+++ b/webdriver-downloader/src/driver_management/driver_impls/chromedriver_info/os_specific/windows.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use semver::Version;
 
-use crate::driver_impls::chromedriver_info::BinaryVersionError;
+use crate::driver_impls::chromedriver_info::VersionReqError;
 
 pub const ZIPFILE_NAME_RE: &str = r"<Key>([0-9\.]*?)/chromedriver_win32.zip</Key>";
 pub const DRIVER_NAME_IN_ARCHIVE: &str = "chromedriver.exe";
@@ -15,7 +15,7 @@ pub fn build_url(version_string: &str) -> String {
     )
 }
 
-pub fn binary_version(browser_path: &Path) -> Result<Version, BinaryVersionError> {
+pub fn binary_version(browser_path: &Path) -> Result<Version, VersionReqError> {
     let mut child = std::process::Command::new("powershell");
 
     let mut command = OsString::from("(Get-Item \"");


### PR DESCRIPTION
- Change binary_version_hint_url_info.rs to version_req_url_info.rs
- The struct has been renamed accordingly.
- Also, it now uses VersionReq instead of using Version.major field.