### PR TITLE
Refactor: change version_req_url_info.

### DIFF
--- a/webdriver-downloader/src/driver_management/common/url_info.rs
+++ b/webdriver-downloader/src/driver_management/common/url_info.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use semver::Version;
+use semver::{Version, VersionReq};
 
 use crate::common::version_req_url_info::VersionReqError;
 
@@ -8,14 +8,15 @@ pub enum UrlError {
     #[error("Failed to download Urls: {0}")]
     Download(#[from] reqwest::Error),
     #[error(transparent)]
-    BinaryVersion(#[from] VersionReqError),
+    VersionReq(#[from] VersionReqError),
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct VersionUrl {
-    pub version: Version,
+pub struct WebdriverVersionUrl {
+    pub version_req: VersionReq,
+    pub webdriver_version: Version,
     pub url: String,
 }
 
@@ -23,5 +24,5 @@ pub struct VersionUrl {
 #[async_trait]
 pub trait WebdriverUrlInfo {
     /// Lists viable VersionUrls, up to `limit`.
-    async fn version_urls(&self, limit: usize) -> Result<Vec<VersionUrl>, UrlError>;
+    async fn version_urls(&self, limit: usize) -> Result<Vec<WebdriverVersionUrl>, UrlError>;
 }

--- a/webdriver-downloader/src/driver_management/mod.rs
+++ b/webdriver-downloader/src/driver_management/mod.rs
@@ -7,8 +7,8 @@ use crate::common::installation_info::{InstallationError, WebdriverInstallationI
 use crate::common::url_info::{UrlError, WebdriverUrlInfo};
 use crate::common::verification_info::{VerificationError, WebdriverVerificationInfo};
 
-pub mod driver_impls;
 pub mod common;
+pub mod driver_impls;
 
 /// Information required to download, verify, install driver.
 #[async_trait]
@@ -48,7 +48,10 @@ where
         let url_count = version_urls.len();
 
         for version_url in version_urls {
-            println!("Trying url for version {}: {}.", version_url.version, version_url.url);
+            println!(
+                "Trying url for version {}: {}.",
+                version_url.webdriver_version, version_url.url
+            );
             let tempdir = TempDir::new()?;
 
             let temp_driver_path = self.download_in_tempdir(version_url.url, &tempdir).await?;

--- a/webdriver-downloader/tests/driver_management/mod.rs
+++ b/webdriver-downloader/tests/driver_management/mod.rs
@@ -5,8 +5,8 @@ mod tests {
     use anyhow::anyhow;
     use mockall::predicate::eq;
     use semver::Version;
-    use webdriver_downloader::common::url_info::VersionUrl;
 
+    use webdriver_downloader::common::url_info::WebdriverVersionUrl;
     use webdriver_downloader::WebdriverInfo;
 
     use crate::MockWebdriverInfo;
@@ -26,8 +26,9 @@ mod tests {
         let mut mock = MockWebdriverInfo::new();
         let version_count = 5;
 
-        let dummy_version_url = VersionUrl {
-            version: Version::new(0, 0, 0),
+        let dummy_version_url = WebdriverVersionUrl {
+            version_req: Default::default(),
+            webdriver_version: Version::new(0, 0, 0),
             url: Default::default(),
         };
         let urls = vec![dummy_version_url; version_count];

--- a/webdriver-downloader/tests/main.rs
+++ b/webdriver-downloader/tests/main.rs
@@ -9,10 +9,11 @@ use tempfile::TempDir;
 use webdriver_downloader::common::installation_info::{
     InstallationError, WebdriverInstallationInfo,
 };
-use webdriver_downloader::common::url_info::{UrlError, VersionUrl, WebdriverUrlInfo};
+use webdriver_downloader::common::url_info::{UrlError, WebdriverUrlInfo, WebdriverVersionUrl};
 use webdriver_downloader::common::verification_info::{
     VerificationError, WebdriverVerificationInfo,
 };
+
 mod driver_management;
 
 mock! {
@@ -21,7 +22,7 @@ mock! {
 
     #[async_trait]
     impl WebdriverUrlInfo for WebdriverInfo {
-        async fn version_urls(&self, limit: usize) -> Result<Vec<VersionUrl>, UrlError>;
+        async fn version_urls(&self, limit: usize) -> Result<Vec<WebdriverVersionUrl>, UrlError>;
     }
 
     #[async_trait]


### PR DESCRIPTION
- Binary version was being used as a VersionReq(therby, webdriver versions are used as Version)
- Now webdriver_version, version_req, binary version are separated.
- Binary version work as Version which is tested by WebdriverVersionUrl.versioon_req.